### PR TITLE
158 babz has more matches than abzb

### DIFF
--- a/TimeTrace/src/models/TREParser.ts
+++ b/TimeTrace/src/models/TREParser.ts
@@ -99,6 +99,7 @@ export abstract class TREParser {
             throw new Error(`Expression ${invalidExpressionWithSmallZFollowedByStar[0]} is not allowed. "*" cannot be used after z as this is inferred as (a|b|c|....|Z)*.`);
         }
 
+        //$ is allowed as an expression, see terminate character: https://monaa.readthedocs.io/en/latest/TRE/
         const expressionWithoutSymbol = /(?<![a-yA-Z)*+])([+*&|$]+)/g;
         const invalidExpression = tre.match(expressionWithoutSymbol);
         if (invalidExpression && invalidExpression.length > 0) {

--- a/TimeTrace/src/models/TREParser.ts
+++ b/TimeTrace/src/models/TREParser.ts
@@ -71,7 +71,7 @@ export abstract class TREParser {
     }
 
     public static validateSymbols(tre: string): void {
-        const symbolsAreValid = /^[a-zA-Z()%\s\d+*|&,.]+$/.test(tre);
+        const symbolsAreValid = /^[a-zA-Z()%\s\d+*|&,.$]+$/.test(tre);
 
         this.validateNumbers(tre);
         this.validateSpecialChars(tre);
@@ -99,7 +99,7 @@ export abstract class TREParser {
             throw new Error(`Expression ${invalidExpressionWithSmallZFollowedByStar[0]} is not allowed. "*" cannot be used after z as this is inferred as (a|b|c|....|Z)*.`);
         }
 
-        const expressionWithoutSymbol = /(?<![a-yA-Z)*+])([+*&|]+)/g;
+        const expressionWithoutSymbol = /(?<![a-yA-Z)*+])([+*&|$]+)/g;
         const invalidExpression = tre.match(expressionWithoutSymbol);
         if (invalidExpression && invalidExpression.length > 0) {
             throw new Error(`Expression ${invalidExpression[0]} must be preceded by a mapped symbol.`);


### PR DESCRIPTION
## Summary 
https://monaa.readthedocs.io/en/latest/TRE/
```
../build/monaa -e 'ABC($)%(1,20)' < ../examples/getting_started/timed_word2.txt
```
- [x] $ is now allowed to be used inside a TRE see terminate character in the link above  

### Reported bug was not a bug
The reason why b|abZ* produced more matches than abZ*|b was due to precedence

```
expr : c (An event)
     | ( expr ) (Grouping)
     | expr + (Kleene Plus)
     | expr * (Kleene Star)
     | expr expr (Concatenation)
     | expr | expr (Disjunction)
     | expr & expr (Conjunction)
     | expr % (s,t) (Time Restriction)
```
